### PR TITLE
Right units for trapping equations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "scipy",
+    "pint"
 ]
 dynamic = ["version"]
 

--- a/src/system_code/__init__.py
+++ b/src/system_code/__init__.py
@@ -1,4 +1,12 @@
-LAMBDA = 1.678e-9  # in s-1
+import pint
+
+ureg = pint.UnitRegistry()
+
+LAMBDA = (1.678e-9 * ureg.s**-1).magnitude  # in s-1
+# T_MASS = 3.01604928132 * ureg.g * ureg.mol**-1  # in g/mol
+# T_MASS = 1  # T_MASS.to(ureg.kg * ureg.particle**-1).magnitude
+
+# T_MASS = 1
 
 from .system import System
 from .box import Box, Trap

--- a/src/system_code/__init__.py
+++ b/src/system_code/__init__.py
@@ -3,10 +3,9 @@ import pint
 ureg = pint.UnitRegistry()
 
 LAMBDA = (1.678e-9 * ureg.s**-1).magnitude  # in s-1
-# T_MASS = 3.01604928132 * ureg.g * ureg.mol**-1  # in g/mol
-# T_MASS = 1  # T_MASS.to(ureg.kg * ureg.particle**-1).magnitude
+T_MASS = 3.01604928132 * ureg.g * ureg.mol**-1  # in g/mol
+T_MASS = T_MASS.to(ureg.kg * ureg.particle**-1).magnitude
 
-# T_MASS = 1
 
 from .system import System
 from .box import Box, Trap

--- a/src/system_code/box.py
+++ b/src/system_code/box.py
@@ -71,9 +71,7 @@ class Box:
 
         self.equation = 0
         # (I - I_n)/dt
-        self.equation += (
-            -(box_inv_map[self] - self.old_inventory) / stepsize
-        )
+        self.equation += -(box_inv_map[self] - self.old_inventory) / stepsize
         # + generation
         self.equation += self.generation_term
         # - lambda*I
@@ -99,12 +97,10 @@ class Box:
 
         # - V_t * k * c * (n - c_t) + V_t * p * c_t
         for trap in self.traps:
-            c_t = box_inv_map[trap]/trap.volume
-            c_m = box_inv_map[self] * trap.solid_fraction/trap.volume
-            self.equation += (
-                -trap.volume
-                * trap.k * c_m * (trap.n - c_t)
-            )
+            c_t = box_inv_map[trap] / trap.volume  # kg/m3
+            c_m = box_inv_map[self] * trap.solid_fraction / trap.volume  # kg/m3
+
+            self.equation += -trap.volume * trap.k * c_m * (trap.n - c_t)
             self.equation += trap.volume * trap.p * c_t
 
     def reset(self):
@@ -128,10 +124,12 @@ class Trap(Box):
         super().build_equation(box_inv_map, stepsize)
 
         # + V * k * c * (n - c_t) - V * p * c_t
-        c_m = box_inv_map[self.parent_box] * self.solid_fraction / self.volume
-        c_t = box_inv_map[self] / self.volume
-        self.equation += (
-            self.volume
-            * self.k * c_m * (self.n - c_t)
-        )
+
+        I_m_s = box_inv_map[self.parent_box] * self.solid_fraction
+        I_t = box_inv_map[self]
+
+        c_m = I_m_s / self.volume  # kg/m3
+        c_t = I_t / self.volume  # kg/m3
+
+        self.equation += self.volume * self.k * c_m * (self.n - c_t)
         self.equation += -self.volume * self.p * c_t

--- a/src/system_code/box.py
+++ b/src/system_code/box.py
@@ -1,4 +1,4 @@
-from system_code import LAMBDA
+from system_code import LAMBDA, T_MASS
 
 
 class Box:
@@ -100,8 +100,20 @@ class Box:
             c_t = box_inv_map[trap] / trap.volume  # kg/m3
             c_m = box_inv_map[self] * trap.solid_fraction / trap.volume  # kg/m3
 
-            self.equation += -trap.volume * trap.k * c_m * (trap.n - c_t)
-            self.equation += trap.volume * trap.p * c_t
+            c_t = c_t / T_MASS  # at / m3
+            c_m = c_m / T_MASS  # at / m3
+
+            trapping_rate = trap.k * c_m * (trap.n - c_t)  # at / m3 / s
+            detrapping_rate = trap.p * c_t  # at / m3 / s
+
+            trapping_rate *= trap.volume  # at / s
+            detrapping_rate *= trap.volume  # at / s
+
+            trapping_rate *= T_MASS  # kg/s
+            detrapping_rate *= T_MASS  # kg/s
+
+            self.equation += -trapping_rate
+            self.equation += detrapping_rate
 
     def reset(self):
         self.inventory = self.initial_inventory
@@ -131,5 +143,17 @@ class Trap(Box):
         c_m = I_m_s / self.volume  # kg/m3
         c_t = I_t / self.volume  # kg/m3
 
-        self.equation += self.volume * self.k * c_m * (self.n - c_t)
-        self.equation += -self.volume * self.p * c_t
+        c_t = c_t / T_MASS  # at / m3
+        c_m = c_m / T_MASS  # at / m3
+
+        trapping_rate = self.k * c_m * (self.n - c_t)  # at / m3 / s
+        detrapping_rate = self.p * c_t  # at / m3 / s
+
+        trapping_rate *= self.volume  # at / s
+        detrapping_rate *= self.volume  # at / s
+
+        trapping_rate *= T_MASS  # kg/s
+        detrapping_rate *= T_MASS  # kg/s
+
+        self.equation += trapping_rate
+        self.equation += -detrapping_rate

--- a/tests/test_traps.py
+++ b/tests/test_traps.py
@@ -2,9 +2,9 @@ import system_code as tsc
 import numpy as np
 import sympy as sp
 
+
 def test_one_box_only():
-    """Makes a simple 'cycle' with 1 box with a trap and checks mass is conserved
-    """
+    """Makes a simple 'cycle' with 1 box with a trap and checks mass is conserved"""
 
     A = tsc.Box("A", initial_inventory=1)
 
@@ -25,6 +25,7 @@ def test_one_box_only():
     # TODO radioactive decay is on, careful
     assert np.isclose(total_inv, A.initial_inventory).all()
 
+
 def test_equation():
     """Checks that the produced equation is the correct one"""
     I_m = sp.Symbol("I_m")
@@ -40,7 +41,15 @@ def test_equation():
 
     A = tsc.Box("A", initial_inventory=I_m_n)
 
-    A_trap = tsc.Trap(k=k, p=p, n=n, volume=V_t, name="A_trap", initial_inventory=I_t_n, solid_fraction=K)
+    A_trap = tsc.Trap(
+        k=k,
+        p=p,
+        n=n,
+        volume=V_t,
+        name="A_trap",
+        initial_inventory=I_t_n,
+        solid_fraction=K,
+    )
 
     A.add_trap(A_trap)
 
@@ -48,8 +57,14 @@ def test_equation():
     A_trap.build_equation({A: I_m, A_trap: I_t}, stepsize=dt)
 
     # test
+    c_m = I_m * K / V_t  # kg/m3
+    c_m = c_m / tsc.MOLAR_MASS  # at/m3
+    c_t = I_t / V_t  # kg/m3
+    c_t = c_t / tsc.MOLAR_MASS  # at/m3
 
-    expected_equation = -(I_t - I_t_n)/dt + k * I_m * K * (n - I_t/V_t) - p*I_t - tsc.LAMBDA*I_t
+    expected_equation = (
+        -(I_t - I_t_n) / dt + V_t * (k * c_m * (n - c_t) - p * c_t) - tsc.LAMBDA * I_t
+    )
     print(expected_equation)
     print(A_trap.equation)
-    assert sp.simplify(A_trap.equation-expected_equation) == 0
+    assert sp.simplify(A_trap.equation - expected_equation) == 0

--- a/tests/test_traps.py
+++ b/tests/test_traps.py
@@ -58,12 +58,15 @@ def test_equation():
 
     # test
     c_m = I_m * K / V_t  # kg/m3
-    c_m = c_m / tsc.MOLAR_MASS  # at/m3
+    c_m = c_m / tsc.T_MASS  # at/m3
+
     c_t = I_t / V_t  # kg/m3
-    c_t = c_t / tsc.MOLAR_MASS  # at/m3
+    c_t = c_t / tsc.T_MASS  # at/m3
 
     expected_equation = (
-        -(I_t - I_t_n) / dt + V_t * (k * c_m * (n - c_t) - p * c_t) - tsc.LAMBDA * I_t
+        -(I_t - I_t_n) / dt
+        + V_t * tsc.T_MASS * (k * c_m * (n - c_t) - p * c_t)
+        - tsc.LAMBDA * I_t
     )
     print(expected_equation)
     print(A_trap.equation)


### PR DESCRIPTION
This PR introduces units (@shimwell), or at least requires users to use units in when dealing with traps.

Because the trapping and detrapping rates expect concentrations (in at/m3) and boxes work with inventories, we had to do some conversion.

When using traps:

- inventories are in kg
- trap densities are in #/m3

Always:
- time is in s